### PR TITLE
Increase test coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,12 +13,17 @@ this project you agree to abide by its terms.
 
 1. You should probably have a Go-capable IDE
    1. Usually either of GoLand or VSCode (but you can use any other IDE of course)
-2. Ensure you have Go SDK 1.18+ installed & working
+2. Ensure you have Go SDK 1.19+ installed & working
 3. Ensure you have Docker installed & working
+4. Ensure you have [Task](https://taskfile.dev/) installed & working
+   ```shell
+   $ brew install go-task/tap/go-task
+   ```
 4. Verify they work by:
    ```shell
    $ docker version
    $ go version
+   $ task --version
    ```
 
 ## Issues and PRs
@@ -34,7 +39,7 @@ at the links below if you're not sure how to open a PR.
 1. [Fork][fork] and clone the repository.
 2. Verify it works & all tests are passing on your machine by:
    ```shell
-   $ go test ./...
+   $ task test
    ```
 3. Create a new branch:
    ```shell

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/client-go/rest"
 	"os"
 	"time"
 
@@ -34,7 +37,53 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+func run(k8sConfig *rest.Config, metricsAddr string, enableLeaderElection bool, probeAddr string, opts zap.Options, ctx context.Context) error {
+
+	// Apply logger
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Create the manager
+	mgr, err := ctrl.NewManager(k8sConfig, ctrl.Options{
+		Scheme:                        scheme,
+		MetricsBindAddress:            metricsAddr,
+		Port:                          9443,
+		HealthProbeBindAddress:        probeAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              "7e5314ff.kude.kfirs.com",
+		LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to start manager: %w", err)
+	}
+
+	// Setup GitRepository reconciler
+	if err := (&internal.GitRepositoryReconciler{WorkDir: "/data"}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller '%s': %w", "GitRepository", err)
+	}
+	if err := (&internal.KubectlBundleReconciler{}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller '%s': %w", "KubectlBundle", err)
+	}
+	//+kubebuilder:scaffold:builder
+
+	// Add health probes
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to set up ready check: %w", err)
+	}
+
+	// Run!
+	setupLog.Info("Starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("problem running manager: %w", err)
+	}
+
+	return nil
+}
+
 func main() {
+
 	// Flags
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -51,49 +100,9 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	// Apply logger
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	// Create the manager
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                        scheme,
-		MetricsBindAddress:            metricsAddr,
-		Port:                          9443,
-		HealthProbeBindAddress:        probeAddr,
-		LeaderElection:                enableLeaderElection,
-		LeaderElectionID:              "7e5314ff.kude.kfirs.com",
-		LeaderElectionReleaseOnCancel: true,
-	})
-	if err != nil {
-		setupLog.Error(err, "Unable to start manager")
-		os.Exit(1)
-	}
-
-	// Setup GitRepository reconciler
-	if err := (&internal.GitRepositoryReconciler{WorkDir: "/data"}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Unable to create controller", "controller", "GitRepository")
-		os.Exit(1)
-	}
-	if err := (&internal.KubectlBundleReconciler{}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Unable to create controller", "controller", "KubectlBundle")
-		os.Exit(1)
-	}
-	//+kubebuilder:scaffold:builder
-
-	// Add health probes
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "Unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "Unable to set up ready check")
-		os.Exit(1)
-	}
-
-	// Run!
-	setupLog.Info("Starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "Manager failed")
+	// Run
+	if err := run(ctrl.GetConfigOrDie(), metricsAddr, enableLeaderElection, probeAddr, opts, ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "Operator failed")
 		os.Exit(1)
 	}
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"github.com/arikkfir/kude-controller/test/harness"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+	"math/rand"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestRun(t *testing.T) {
+	k8sConfig, _, _ := harness.SetupServer(t)
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.TimeEncoderOfLayout(time.StampMilli),
+	}
+
+	metricsRandPort := rand.Intn(10) + 8080
+	probeRandPort := metricsRandPort + 1
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		t.Log("Stopping manager")
+		cancel()
+	})
+	go func() {
+		if err := run(k8sConfig, ":"+strconv.Itoa(metricsRandPort), false, ":"+strconv.Itoa(probeRandPort), opts, ctx); err != nil {
+			t.Errorf("Failed to run manager: %v", err)
+		}
+	}()
+
+	// Wait for the manager to start
+	time.Sleep(5 * time.Second)
+
+	if resp, err := http.Get("http://localhost:" + strconv.Itoa(metricsRandPort) + "/metrics"); assert.NoErrorf(t, err, "Failed to get metrics") {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+	if resp, err := http.Get("http://localhost:" + strconv.Itoa(probeRandPort) + "/healthz"); assert.NoErrorf(t, err, "Failed to get healthz") {
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  notify:
+    after_n_builds: 1
+
+coverage:
+  round: nearest
+  range: "50...100"
+  status:
+    project:
+      default:
+        threshold: 2%
+    patch: off
+    changes: off

--- a/internal/gitrepository_controller.go
+++ b/internal/gitrepository_controller.go
@@ -74,10 +74,10 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// If marked for deletion, perform actual deletion & remove finalizer
 	if o.DeletionTimestamp != nil {
 		if res, err := r.setCondition(ctx, &o, typeDegradedGitRepository, metav1.ConditionTrue, "Deleted", "Deleting resource"); res.Requeue || err != nil {
-			return ctrl.Result{}, err
+			return res, err
 		}
 		if res, err := r.setCondition(ctx, &o, typeAvailableGitRepository, metav1.ConditionFalse, "Deleted", "Deleting resource"); res.Requeue || err != nil {
-			return ctrl.Result{}, err
+			return res, err
 		}
 		if o.Status.WorkDirectory != "" {
 			if strings.HasPrefix(o.Status.WorkDirectory, r.WorkDir+"/") {
@@ -96,7 +96,7 @@ func (r *GitRepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 		}
 		if res, err := r.setCondition(ctx, &o, typeClonedGitRepository, metav1.ConditionFalse, "CloneDeleted", ""); res.Requeue || err != nil {
-			return ctrl.Result{}, err
+			return res, err
 		}
 		if controllerutil.RemoveFinalizer(&o, finalizerGitRepository) {
 			if err := r.Client.Update(ctx, &o); err != nil {

--- a/internal/gitrepository_controller_test.go
+++ b/internal/gitrepository_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 )
@@ -128,4 +129,63 @@ func TestGitRepositoryClone(t *testing.T) {
 	}, 5*time.Second, 1*time.Second, "resource not cloned correctly")
 
 	// TODO: verify clone dir
+}
+
+func TestGitRepositoryDeletion(t *testing.T) {
+	k8sClient, _ := harness.SetupTestEnv(t, &KubectlBundleReconciler{})
+
+	repo := &v1alpha1.GitRepository{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.GitRepository{}).Name(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "repo1",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.GitRepositorySpec{
+			Branch:          "refs/heads/main",
+			PollingInterval: "5s",
+		},
+	}
+	lookupKey := types.NamespacedName{Name: repo.Name, Namespace: repo.Namespace}
+
+	ctx := context.Background()
+	require.NoErrorf(t, k8sClient.Create(ctx, repo), "resource creation failed")
+	time.Sleep(3 * time.Second)
+	require.NoErrorf(t, k8sClient.Delete(ctx, repo), "resource deletion failed")
+	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+		var r v1alpha1.GitRepository
+		if assert.NoErrorf(c, k8sClient.Get(ctx, lookupKey, &r), "resource lookup failed") {
+
+			cDegraded := meta.FindStatusCondition(r.Status.Conditions, typeDegradedGitRepository)
+			assert.Equal(c, metav1.ConditionTrue, cDegraded.Status, "incorrect status")
+			assert.Equal(c, "Deleted", cDegraded.Reason, "incorrect reason")
+			assert.Equal(c, "Deleting resource", cDegraded.Message, "incorrect message")
+
+			cUpToDate := meta.FindStatusCondition(r.Status.Conditions, typeAvailableGitRepository)
+			assert.Equal(c, metav1.ConditionFalse, cUpToDate.Status, "incorrect status")
+			assert.Equal(c, "Deleted", cUpToDate.Reason, "incorrect reason")
+			assert.Equal(c, "Deleting resource", cUpToDate.Message, "incorrect message")
+
+			cCloned := meta.FindStatusCondition(r.Status.Conditions, typeClonedGitRepository)
+			assert.Equal(c, metav1.ConditionFalse, cCloned.Status, "incorrect status")
+			assert.Equal(c, "Deleted", cCloned.Reason, "incorrect reason")
+			assert.Equal(c, "", cCloned.Message, "incorrect message")
+
+			assert.Equal(c, "", r.Status.WorkDirectory)
+
+			assert.NotContains(c, r.Finalizers, finalizerGitRepository, "finalizer found")
+		}
+	}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
+
+	if assert.NoErrorf(t, k8sClient.Get(ctx, lookupKey, repo), "resource lookup failed") {
+		assert.Equal(t, []string{"Tests"}, repo.Finalizers)
+		repo.ObjectMeta.Finalizers = []string{}
+		require.NoErrorf(t, k8sClient.Update(ctx, repo), "finalizer removal failed")
+		assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+			var r v1alpha1.GitRepository
+			assert.NoError(c, client.IgnoreNotFound(k8sClient.Get(ctx, lookupKey, &r)))
+		}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
+	}
 }

--- a/internal/gitrepository_controller_test.go
+++ b/internal/gitrepository_controller_test.go
@@ -142,6 +142,9 @@ func TestGitRepositoryDeletion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "repo1",
 			Namespace: "default",
+			Finalizers: []string{
+				"Tests",
+			},
 		},
 		Spec: v1alpha1.GitRepositorySpec{
 			Branch:          "refs/heads/main",
@@ -177,7 +180,7 @@ func TestGitRepositoryDeletion(t *testing.T) {
 
 			assert.NotContains(c, r.Finalizers, finalizerGitRepository, "finalizer found")
 		}
-	}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
+	}, 15*time.Second, 1*time.Second, "resource not finalized correctly")
 
 	if assert.NoErrorf(t, k8sClient.Get(ctx, lookupKey, repo), "resource lookup failed") {
 		assert.Equal(t, []string{"Tests"}, repo.Finalizers)

--- a/internal/gitrepository_controller_test.go
+++ b/internal/gitrepository_controller_test.go
@@ -28,7 +28,7 @@ func init() {
 	}
 }
 
-func TestIgnoreMissingResource(t *testing.T) {
+func TestIgnoreMissingGitRepositoryResource(t *testing.T) {
 	reconciler := &GitRepositoryReconciler{}
 	_, _ = harness.SetupTestEnv(t, reconciler)
 

--- a/internal/kubectlbundle_controller_test.go
+++ b/internal/kubectlbundle_controller_test.go
@@ -6,12 +6,30 @@ import (
 	"github.com/arikkfir/kude-controller/test/harness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"reflect"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 )
+
+func TestIgnoreMissingKubectlBundleResource(t *testing.T) {
+	reconciler := &KubectlBundleReconciler{}
+	_, _ = harness.SetupTestEnv(t, reconciler)
+
+	time.Sleep(5 * time.Second) // Give manager and cache time to start; needed since we're directly invoking controller
+	res, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "ns1",
+			Name:      "r1",
+		},
+	})
+	assert.NoErrorf(t, err, "expected reconciliation for missing resource NOT to fail")
+	assert.Falsef(t, res.Requeue, "expected reconciliation for missing resource NOT to request requeuing, got: %+v", res)
+}
 
 func TestKubectlBundleInitialization(t *testing.T) {
 	k8sClient, _ := harness.SetupTestEnv(t, &KubectlBundleReconciler{})
@@ -41,4 +59,61 @@ func TestKubectlBundleInitialization(t *testing.T) {
 			assert.Contains(c, r.Finalizers, finalizerKubectlBundle, "finalizer not found")
 		}
 	}, 5*time.Second, 1*time.Second, "resource not cloned correctly")
+}
+
+func TestKubectlBundleDeletion(t *testing.T) {
+	k8sClient, _ := harness.SetupTestEnv(t, &KubectlBundleReconciler{})
+
+	bundle := &v1alpha1.KubectlBundle{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       reflect.TypeOf(v1alpha1.KubectlBundle{}).Name(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bundle1",
+			Namespace: "default",
+			Finalizers: []string{
+				"Tests",
+			},
+		},
+		Spec: v1alpha1.KubectlBundleSpec{
+			DriftDetectionInterval: "5sec",
+			SourceRepository:       "ns1/repo1",
+			Files:                  []string{"*.yaml"},
+		},
+	}
+	lookupKey := types.NamespacedName{Name: bundle.Name, Namespace: bundle.Namespace}
+
+	ctx := context.Background()
+	require.NoErrorf(t, k8sClient.Create(ctx, bundle), "resource creation failed")
+	time.Sleep(3 * time.Second)
+	require.NoErrorf(t, k8sClient.Delete(ctx, bundle), "resource deletion failed")
+	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+		var r v1alpha1.KubectlBundle
+		if assert.NoErrorf(c, k8sClient.Get(ctx, lookupKey, &r), "resource lookup failed") {
+
+			cDegraded := meta.FindStatusCondition(r.Status.Conditions, typeDegradedKubectlBundle)
+			assert.Equal(c, metav1.ConditionTrue, cDegraded.Status, "incorrect status")
+			assert.Equal(c, "Deleted", cDegraded.Reason, "incorrect reason")
+			assert.Equal(c, "Deleting resource", cDegraded.Message, "incorrect message")
+
+			cUpToDate := meta.FindStatusCondition(r.Status.Conditions, typeUpToDateKubectlBundle)
+			assert.Equal(c, metav1.ConditionUnknown, cUpToDate.Status, "incorrect status")
+			assert.Equal(c, "Deleted", cUpToDate.Reason, "incorrect reason")
+			assert.Equal(c, "Deleting resource", cUpToDate.Message, "incorrect message")
+
+			assert.NotContains(c, r.Finalizers, finalizerKubectlBundle, "finalizer not found")
+		}
+	}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
+
+	if assert.NoErrorf(t, k8sClient.Get(ctx, lookupKey, bundle), "resource lookup failed") {
+		assert.Equal(t, []string{"Tests"}, bundle.Finalizers)
+		bundle.ObjectMeta.Finalizers = []string{}
+		require.NoErrorf(t, k8sClient.Update(ctx, bundle), "finalizer removal failed")
+		assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+			var r v1alpha1.KubectlBundle
+			assert.NoError(c, client.IgnoreNotFound(k8sClient.Get(ctx, lookupKey, &r)))
+		}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
+	}
+
 }

--- a/internal/kubectlbundle_controller_test.go
+++ b/internal/kubectlbundle_controller_test.go
@@ -93,14 +93,18 @@ func TestKubectlBundleDeletion(t *testing.T) {
 		if assert.NoErrorf(c, k8sClient.Get(ctx, lookupKey, &r), "resource lookup failed") {
 
 			cDegraded := meta.FindStatusCondition(r.Status.Conditions, typeDegradedKubectlBundle)
-			assert.Equal(c, metav1.ConditionTrue, cDegraded.Status, "incorrect status")
-			assert.Equal(c, "Deleted", cDegraded.Reason, "incorrect reason")
-			assert.Equal(c, "Deleting resource", cDegraded.Message, "incorrect message")
+			if assert.NotNil(c, cDegraded, "degraded condition not found") {
+				assert.Equal(c, metav1.ConditionTrue, cDegraded.Status, "incorrect status")
+				assert.Equal(c, "Deleted", cDegraded.Reason, "incorrect reason")
+				assert.Equal(c, "Deleting resource", cDegraded.Message, "incorrect message")
+			}
 
 			cUpToDate := meta.FindStatusCondition(r.Status.Conditions, typeUpToDateKubectlBundle)
-			assert.Equal(c, metav1.ConditionUnknown, cUpToDate.Status, "incorrect status")
-			assert.Equal(c, "Deleted", cUpToDate.Reason, "incorrect reason")
-			assert.Equal(c, "Deleting resource", cUpToDate.Message, "incorrect message")
+			if assert.NotNil(c, cUpToDate, "uptodate condition not found") {
+				assert.Equal(c, metav1.ConditionUnknown, cUpToDate.Status, "incorrect status")
+				assert.Equal(c, "Deleted", cUpToDate.Reason, "incorrect reason")
+				assert.Equal(c, "Deleting resource", cUpToDate.Message, "incorrect message")
+			}
 
 			assert.NotContains(c, r.Finalizers, finalizerKubectlBundle, "finalizer found")
 		}

--- a/internal/kubectlbundle_controller_test.go
+++ b/internal/kubectlbundle_controller_test.go
@@ -102,7 +102,7 @@ func TestKubectlBundleDeletion(t *testing.T) {
 			assert.Equal(c, "Deleted", cUpToDate.Reason, "incorrect reason")
 			assert.Equal(c, "Deleting resource", cUpToDate.Message, "incorrect message")
 
-			assert.NotContains(c, r.Finalizers, finalizerKubectlBundle, "finalizer not found")
+			assert.NotContains(c, r.Finalizers, finalizerKubectlBundle, "finalizer found")
 		}
 	}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
 
@@ -115,5 +115,4 @@ func TestKubectlBundleDeletion(t *testing.T) {
 			assert.NoError(c, client.IgnoreNotFound(k8sClient.Get(ctx, lookupKey, &r)))
 		}, 5*time.Second, 1*time.Second, "resource not finalized correctly")
 	}
-
 }

--- a/internal/kubectlbundle_controller_test.go
+++ b/internal/kubectlbundle_controller_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"github.com/arikkfir/kude-controller/internal/v1alpha1"
+	"github.com/arikkfir/kude-controller/test/harness"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestKubectlBundleInitialization(t *testing.T) {
-	k8sClient, _ := setupTestEnv(t, &KubectlBundleReconciler{})
+	k8sClient, _ := harness.SetupTestEnv(t, &KubectlBundleReconciler{})
 
 	bundle := &v1alpha1.KubectlBundle{
 		TypeMeta: metav1.TypeMeta{

--- a/test/harness/test_writer.go
+++ b/test/harness/test_writer.go
@@ -1,0 +1,13 @@
+package harness
+
+import "testing"
+
+type testWriter struct {
+	T *testing.T
+}
+
+func (tw *testWriter) Write(p []byte) (n int, err error) {
+	tw.T.Helper()
+	tw.T.Logf("%s", p)
+	return len(p), nil
+}


### PR DESCRIPTION
This PR adds more tests to increase our testing coverage. Specifically, it adds a CLI runner test, which required refactoring the Kubernetes testing harness so it is available for other packages and not local to the "internal" package.