### PR TITLE
Fix random port allocation in CLI test

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -5,10 +5,8 @@ import (
 	"github.com/arikkfir/kude-controller/test/harness"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
-	"math/rand"
 	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -20,15 +18,21 @@ func TestRun(t *testing.T) {
 		TimeEncoder: zapcore.TimeEncoderOfLayout(time.StampMilli),
 	}
 
-	metricsRandPort := rand.Intn(10) + 8080
-	probeRandPort := metricsRandPort + 1
+	metricsHost, err := harness.FindFreeLocalAddr()
+	if err != nil {
+		t.Fatalf("Failed to allocate a random local address for metrics host: %v", err)
+	}
+	healthHost, err := harness.FindFreeLocalAddr()
+	if err != nil {
+		t.Fatalf("Failed to allocate a random local address for health host: %v", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
 		t.Log("Stopping manager")
 		cancel()
 	})
 	go func() {
-		if err := run(k8sConfig, ":"+strconv.Itoa(metricsRandPort), false, ":"+strconv.Itoa(probeRandPort), opts, ctx); err != nil {
+		if err := run(k8sConfig, metricsHost, false, healthHost, opts, ctx); err != nil {
 			t.Errorf("Failed to run manager: %v", err)
 		}
 	}()
@@ -36,10 +40,12 @@ func TestRun(t *testing.T) {
 	// Wait for the manager to start
 	time.Sleep(5 * time.Second)
 
-	if resp, err := http.Get("http://localhost:" + strconv.Itoa(metricsRandPort) + "/metrics"); assert.NoErrorf(t, err, "Failed to get metrics") {
+	if //goland:noinspection HttpUrlsUsage
+	resp, err := http.Get("http://" + metricsHost + "/metrics"); assert.NoErrorf(t, err, "Failed to get metrics") {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	}
-	if resp, err := http.Get("http://localhost:" + strconv.Itoa(probeRandPort) + "/healthz"); assert.NoErrorf(t, err, "Failed to get healthz") {
+	if //goland:noinspection HttpUrlsUsage
+	resp, err := http.Get("http://" + healthHost + "/healthz"); assert.NoErrorf(t, err, "Failed to get healthz") {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 }

--- a/test/harness/addr.go
+++ b/test/harness/addr.go
@@ -1,0 +1,20 @@
+package harness
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+func FindFreeLocalAddr() (string, error) {
+	if addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("localhost", "0")); err != nil {
+		return "", fmt.Errorf("failed to resolve a local TCP address: %w", err)
+	} else if listener, err := net.ListenTCP("tcp", addr); err != nil {
+		return "", fmt.Errorf("failed to listen the randomly chosen addr '%s': %w", addr, err)
+	} else {
+		if err := listener.Close(); err != nil {
+			return "", fmt.Errorf("failed to release chosen addr '%s': %w", addr, err)
+		}
+		return addr.IP.String() + ":" + strconv.Itoa(listener.Addr().(*net.TCPAddr).Port), nil
+	}
+}


### PR DESCRIPTION
The CLI test tried to allocate random ports, but it did not check for those random ports' availability. This change allocates a random free port properly.